### PR TITLE
Fixed reg expression to find libopenblas in InnoSetup

### DIFF
--- a/windows_setup.iss
+++ b/windows_setup.iss
@@ -99,7 +99,7 @@ Source: "dist\main\base_library.zip"; DestDir: "{app}"; Flags: ignoreversion
 Source: "dist\main\LEGAL NOTICES.md"; DestDir: "{app}"; Flags: ignoreversion
 Source: "dist\main\libcrypto-1_1.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "dist\main\libffi-7.dll"; DestDir: "{app}"; Flags: ignoreversion
-Source: "dist\main\libopenblas.*.gfortran-win_amd64.dll"; DestDir: "{app}"; Flags: ignoreversion
+Source: "dist\main\libopenblas*.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "dist\main\libssl-1_1.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "dist\main\mfc140u.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "dist\main\pyexpat.pyd"; DestDir: "{app}"; Flags: ignoreversion


### PR DESCRIPTION
GitHub uses a different suffix in the library name for the compiler