### PR TITLE
Update main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,8 @@
-from pywr_editor import app
+import multiprocessing
 
 if __name__ == "__main__":
+    # Freeze the program so it can be run as a standalone executable
+    multiprocessing.freeze_support()
+    from pywr_editor import app
+    # Run the app
     app()


### PR DESCRIPTION
from multiprocessing import freeze_support is used to provide support for freezing the execution environment when using the multiprocessing module in a Python program that is to be packaged with pyinstaller on Windows systems.

without freeze_support, when a child process is spawned in Windows, it might re-import and re-execute the code that creates the child processes, leading to an endless creation of new processes. freeze_support ensures that this doesn't happen and the program runs smoothly with the expected number of processes.